### PR TITLE
Skip INTRODUCTION tags in XML parser

### DIFF
--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -62,6 +62,8 @@ class BaseParser:
             self.common[-1].desc, self.common[-1].desc_attr = self.parseDescDirect(xmlElem)
         elif xmlElem.tag == 'LONG-NAME':
             self.common[-1].longName, self.common[-1].longName_attr = self.parseLongNameDirect(xmlElem)
+        elif xmlElem.tag == 'INTRODUCTION':
+            pass
         else:
             raise NotImplementedError(xmlElem.tag)
     


### PR DESCRIPTION
Tests executed:

$ ./run_tests.sh
test_create_application_software_component (arxml.ar3_component_test.ARXML3ComponentTest.test_create_application_software_component) ... ok
test_create_cdd_software_component (arxml.ar3_component_test.ARXML3ComponentTest.test_create_cdd_software_component) ... ok
test_create_service_software_component (arxml.ar3_component_test.ARXML3ComponentTest.test_create_service_software_component) ... ok
test_create_array_record_constant (arxml.ar3_constant_test.ARXML3ConstantTest.test_create_array_record_constant) ... ok
test_create_integer_constant (arxml.ar3_constant_test.ARXML3ConstantTest.test_create_integer_constant) ... ok
test_create_enumeration_types (arxml.ar3_datatype_test.ARXML3DataTypeTest.test_create_enumeration_types) ... ok
test_create_integer_types_with_unit (arxml.ar3_datatype_test.ARXML3DataTypeTest.test_create_integer_types_with_unit) ... ok
test_create_platform_integer_types (arxml.ar3_datatype_test.ARXML3DataTypeTest.test_create_platform_integer_types) ... ok
test_create_record_type_array (arxml.ar3_datatype_test.ARXML3DataTypeTest.test_create_record_type_array) ... ok
test_create_record_type_simple (arxml.ar3_datatype_test.ARXML3DataTypeTest.test_create_record_type_simple) ... ok
test_create_sender_receiver_interface_single_element (arxml.ar3_portinterface_test.ARXML3PortInterfaceTest.test_create_sender_receiver_interface_single_element) ... ok
test_create_empty_behavior_from_swc (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_empty_behavior_from_swc) ... ok
test_create_runnable_require_type_mode_access (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_runnable_require_type_mode_access) ... ok
test_create_runnable_with_init_event (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_runnable_with_init_event) ... ok
test_create_runnable_with_mode_switch_ack_event_trigger (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_runnable_with_mode_switch_ack_event_trigger) ... ok
test_create_runnable_with_provide_type_mode_access (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_runnable_with_provide_type_mode_access) ... ok
test_create_runnable_with_provide_type_mode_switch_point (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_runnable_with_provide_type_mode_switch_point) ... ok
test_create_runnable_with_require_type_mode_switch_trigger (arxml.ar4_behavior_test.ARXML4BehaviorTest.test_create_runnable_with_require_type_mode_switch_trigger) ... ok
test_create_application_software_component (arxml.ar4_component_test.ARXML4ComponentTest.test_create_application_software_component) ... ok
test_create_application_software_component_with_invalid_ports (arxml.ar4_component_test.ARXML4ComponentTest.test_create_application_software_component_with_invalid_ports) ... ok
test_create_application_software_component_with_nvdata_ports (arxml.ar4_component_test.ARXML4ComponentTest.test_create_application_software_component_with_nvdata_ports) ... ok
test_create_cdd_software_component (arxml.ar4_component_test.ARXML4ComponentTest.test_create_cdd_software_component) ... ok
test_create_composition_component (arxml.ar4_component_test.ARXML4ComponentTest.test_create_composition_component) ... ok
test_create_composition_component_with_one_inner_swc (arxml.ar4_component_test.ARXML4ComponentTest.test_create_composition_component_with_one_inner_swc) ... ok
test_create_data_received_event (arxml.ar4_component_test.ARXML4ComponentTest.test_create_data_received_event) ... ok
test_create_nvblock_software_component (arxml.ar4_component_test.ARXML4ComponentTest.test_create_nvblock_software_component) ... ok
test_create_server_component (arxml.ar4_component_test.ARXML4ComponentTest.test_create_server_component) ... ok
test_create_service_software_component (arxml.ar4_component_test.ARXML4ComponentTest.test_create_service_software_component) ... ok
test_create_swc_with_queued_receiver_com_spec (arxml.ar4_component_test.ARXML4ComponentTest.test_create_swc_with_queued_receiver_com_spec) ... ok
test_create_swc_with_queued_sender_com_spec (arxml.ar4_component_test.ARXML4ComponentTest.test_create_swc_with_queued_sender_com_spec) ... ok
test_load_and_save_application_software_component_with_nvdata_ports (arxml.ar4_component_test.ARXML4ComponentTest.test_load_and_save_application_software_component_with_nvdata_ports) ... ok
test_create_application_value1 (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_application_value1) ... ok
test_create_application_value2 (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_application_value2) ... ok
test_create_array_constant (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_array_constant) ... ok
test_create_array_of_record_constant (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_array_of_record_constant) ... ok
test_create_impl_string_constant (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_impl_string_constant) ... ok
test_create_num_value_constant (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_num_value_constant) ... ok
test_create_record_constant1 (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_record_constant1) ... ok
test_create_record_constant2 (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_record_constant2) ... ok
test_create_record_constant3 (arxml.ar4_constant_test.ARXML4ConstantTest.test_create_record_constant3) ... ok
test_auto_create_compumethod_and_unit (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_auto_create_compumethod_and_unit) ... ok
test_auto_create_constraint (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_auto_create_constraint) ... ok
test_create_adt_with_auto_constraint (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_adt_with_auto_constraint) ... ok
test_create_adt_with_data_constraint_and_compu_method (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_adt_with_data_constraint_and_compu_method) ... ok
test_create_application_record_adt (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_application_record_adt) ... ok
test_create_base_type_without_size (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_base_type_without_size) ... ok
test_create_boolean_compu_method (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_boolean_compu_method) ... ok
test_create_boolean_implementation_datatype (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_boolean_implementation_datatype) ... ok
test_create_float_value_type (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_float_value_type) ... ok
test_create_float_value_type_with_type_emitter (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_float_value_type_with_type_emitter) ... ok
test_create_implementation_array_datatype (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_implementation_array_datatype) ... ok
test_create_implementation_data_type_with_symbol_props (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_implementation_data_type_with_symbol_props) ... ok
test_create_implementation_ref_type (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_implementation_ref_type) ... ok
test_create_implementation_ref_type_implicit_constraint (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_implementation_ref_type_implicit_constraint) ... ok
test_create_implentation_record_type1 (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_implentation_record_type1) ... ok
test_create_integer_implementation_types (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_integer_implementation_types) ... ok
test_create_internal_constraint (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_internal_constraint) ... ok
test_create_linear_compu_method (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_linear_compu_method) ... ok
test_create_phys_to_int_compu_method_rational (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_phys_to_int_compu_method_rational) ... ok
test_create_physical_constraint (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_physical_constraint) ... ok
test_create_physical_constraint_with_level (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_physical_constraint_with_level) ... ok
test_create_record_type2 (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_record_type2) ... ok
test_create_ref_type_with_bitmask (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_ref_type_with_bitmask) ... ok
test_create_ref_type_with_valueTable (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_ref_type_with_valueTable) ... ok
test_create_u8_application_array_data_type (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_u8_application_array_data_type) ... ok
test_create_u8_application_data_type (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_u8_application_data_type) ... ok
test_create_unit (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_create_unit) ... ok
test_custom_constraint_on_impl_typ (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_custom_constraint_on_impl_typ) ... ok
test_int_to_phys_rational_compu_method (arxml.ar4_datatype_test.ARXML4DataTypeTest.test_int_to_phys_rational_compu_method) ... ok
test_create_mode_declaration_with_assigned_values (arxml.ar4_mode_test.ARXML4ModeTest.test_create_mode_declaration_with_assigned_values) ... ok
test_create_mode_type_mapping (arxml.ar4_mode_test.ARXML4ModeTest.test_create_mode_type_mapping) ... ok
test_create_simple_mode_decl_group (arxml.ar4_mode_test.ARXML4ModeTest.test_create_simple_mode_decl_group) ... ok
test_create_mode_provide_port (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_mode_provide_port) ... ok
test_create_mode_require_port (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_mode_require_port) ... ok
test_create_non_queued_provider_port_single_data_element_direct_comspec (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_provider_port_single_data_element_direct_comspec) ... ok
test_create_non_queued_receiver_port_containing_single_data_element_with_alive_timeout (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_receiver_port_containing_single_data_element_with_alive_timeout) ... ok
test_create_non_queued_receiver_port_single_data_element (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_receiver_port_single_data_element) ... ok
test_create_non_queued_receiver_port_single_data_element_direct_comspec1 (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_receiver_port_single_data_element_direct_comspec1) ... ok
test_create_non_queued_receiver_port_single_data_element_direct_comspec2 (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_receiver_port_single_data_element_direct_comspec2)
Same as previous test but does not explicitly name the dataElement (should auto-resolve name) ... ok
test_create_non_queued_sender_port_single_data_element (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_sender_port_single_data_element) ... ok
test_create_non_queued_sender_port_single_data_element_with_raw_init_value (arxml.ar4_port_test.ARXML4PortCreateTest.test_create_non_queued_sender_port_single_data_element_with_raw_init_value) ... ok
test_create_client_server_interface_single_operation_no_return_is_service (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_client_server_interface_single_operation_no_return_is_service) ... ok
test_create_client_server_interface_single_operation_no_return_no_service (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_client_server_interface_single_operation_no_return_no_service) ... ok
test_create_client_server_interface_single_operation_no_return_with_desc (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_client_server_interface_single_operation_no_return_with_desc) ... ok
test_create_mode_switch_interface (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_mode_switch_interface) ... ok
test_create_nv_data_interface_multiple_elements (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_nv_data_interface_multiple_elements) ... ok
test_create_nv_data_interface_single_element (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_nv_data_interface_single_element) ... ok
test_create_parameter_interface (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_parameter_interface) ... ok
test_create_sender_receiver_interface_multiple_elements (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_sender_receiver_interface_multiple_elements) ... ok
test_create_sender_receiver_interface_single_element (arxml.ar4_portinterface_test.ARXML4PortInterfaceTest.test_create_sender_receiver_interface_single_element) ... ok
test_create_swc_implementation (arxml.ar4_swc_implementation_test.ARXML4ComponentTest.test_create_swc_implementation) ... ok
test_create_swc_implementation_memsections (arxml.ar4_swc_implementation_test.ARXML4ComponentTest.test_create_swc_implementation_memsections) ... ok
test_create_array (arxml.ar4_value_builder_test.ARXML4ValueBuilderTest.test_create_array) ... ok
test_create_array_of_records (arxml.ar4_value_builder_test.ARXML4ValueBuilderTest.test_create_array_of_records) ... ok
test_create_float (arxml.ar4_value_builder_test.ARXML4ValueBuilderTest.test_create_float) ... ok
test_create_integer (arxml.ar4_value_builder_test.ARXML4ValueBuilderTest.test_create_integer) ... ok
test_create_record (arxml.ar4_value_builder_test.ARXML4ValueBuilderTest.test_create_record) ... ok
test_create_text (arxml.ar4_value_builder_test.ARXML4ValueBuilderTest.test_create_text) ... ok
test_filter (base_test.TestBase.test_filter) ... ok
test_parseAutosarVersionAndSchema3 (base_test.TestBase.test_parseAutosarVersionAndSchema3) ... ok
test_parseAutosarVersionAndSchema4 (base_test.TestBase.test_parseAutosarVersionAndSchema4) ... ok
test_parseAutosarVersionAndSchemaWithReleaseVersion (base_test.TestBase.test_parseAutosarVersionAndSchemaWithReleaseVersion) ... ok
test_parseVersionString (base_test.TestBase.test_parseVersionString) ... ok
test_prepare_filters (base_test.TestBase.test_prepare_filters) ... ok
test_ws_version (base_test.TestBase.test_ws_version) ... ok
test_createEmptyParameterInterface_AR4 (element_create_test.TestParameterInterfaceCreate.test_createEmptyParameterInterface_AR4) ... ok
test_createParameterInterface_AR4 (element_create_test.TestParameterInterfaceCreate.test_createParameterInterface_AR4) ... ok
test_createFloat_AR4_type (element_create_test.TestRealTypeCreate.test_createFloat_AR4_type) ... ok
test_createRealType_AR3_by_explicit_minmax_types (element_create_test.TestRealTypeCreate.test_createRealType_AR3_by_explicit_minmax_types) ... ok
test_createRealType_AR3_with_inf (element_create_test.TestRealTypeCreate.test_createRealType_AR3_with_inf) ... ok
test_createRealType_AR3_with_infinite (element_create_test.TestRealTypeCreate.test_createRealType_AR3_with_infinite) ... ok
test_createRealType_AR3_with_infinite_negative (element_create_test.TestRealTypeCreate.test_createRealType_AR3_with_infinite_negative) ... ok
test_createRealType_AR4_with_no_constraint_package_set (element_create_test.TestRealTypeCreate.test_createRealType_AR4_with_no_constraint_package_set) ... ok

----------------------------------------------------------------------
Ran 113 tests in 0.910s

OK
